### PR TITLE
mark athlete data as deleted and update sync timestamp on deletion

### DIFF
--- a/public/scripts.js
+++ b/public/scripts.js
@@ -185,7 +185,9 @@ window.testAthlete = async (athlete_id) => {
 window.deleteAthlete = async (athlete_id) => {
   if (await confirm("Are you sure you want to delete this athlete's data?")) {
     for (const test of athletes[athlete_id]) {
+      // mark as deleted and bump update time so sync wins on other devices
       tests[test].athlete_id = "deleted";
+      tests[test].test_updated_at = Date.now();
     }
     document.getElementById("athlete-" + athlete_id).remove();
     await syncData();


### PR DESCRIPTION
Deleting an athlete now marks each test as deleted and refreshes [test_updated_at], ensuring sync treats the deletion as newer and propagates to other devices using the same account ([scripts.js:185-194]).
Now try deleting an athlete on one device, run Sync there, then sync on a second device to confirm the athlete no longer appears.
Closes #1 